### PR TITLE
Fix 403s from Syn due to unreadable config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN curl https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_HA
     #echo "ServerName localhost" | tee /etc/apache2/conf-available/servername.conf && \
     #a2enconf servername && \
     a2enmod rewrite deflate headers expires proxy proxy_http proxy_html proxy_connect remoteip xml2enc cache_disk && \
-    rm -rf /opt/crayfish/Houdini/var/cache
+    php /opt/crayfish/Houdini/bin/console cache:clear
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ RUN curl https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_HA
     a2dissite 000-default && \
     #echo "ServerName localhost" | tee /etc/apache2/conf-available/servername.conf && \
     #a2enconf servername && \
-    a2enmod rewrite deflate headers expires proxy proxy_http proxy_html proxy_connect remoteip xml2enc cache_disk
+    a2enmod rewrite deflate headers expires proxy proxy_http proxy_html proxy_connect remoteip xml2enc cache_disk && \
+    rm -rf /opt/crayfish/Houdini/var/cache
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
For some reason, the presence of var/cache causes a failure in Syn to
read its baked-in xml config file.  Clearing this cache seems to
reliably fix the issue, for reasons unknown